### PR TITLE
[Feat] #13 - 공용 UIButton 구현 (Gray, Orange)

### DIFF
--- a/CDS_CarrotJob/CDS_CarrotJob.xcodeproj/project.pbxproj
+++ b/CDS_CarrotJob/CDS_CarrotJob.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		037C36272A138C0600FAC78B /* NotoSansKR-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 037C36252A138C0600FAC78B /* NotoSansKR-Medium.otf */; };
 		586BF3002A113B08002AD443 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586BF2FF2A113B08002AD443 /* UIImage+.swift */; };
 		586BF3022A114204002AD443 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586BF3012A114204002AD443 /* UIFont+.swift */; };
+		58ACBD512A1474A2005EF7A4 /* GrayUIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ACBD502A1474A2005EF7A4 /* GrayUIButton.swift */; };
+		58ACBD532A1474AC005EF7A4 /* OrangeUIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ACBD522A1474AC005EF7A4 /* OrangeUIButton.swift */; };
 		58D304E12A11F174005E04CB /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 58D304E02A11F174005E04CB /* .swiftlint.yml */; };
 		D3D03F762A10D9B9005AEE77 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D03F752A10D9B9005AEE77 /* AppDelegate.swift */; };
 		D3D03F782A10D9B9005AEE77 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D03F772A10D9B9005AEE77 /* SceneDelegate.swift */; };
@@ -73,6 +75,8 @@
 		037C36252A138C0600FAC78B /* NotoSansKR-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansKR-Medium.otf"; sourceTree = "<group>"; };
 		586BF2FF2A113B08002AD443 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		586BF3012A114204002AD443 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
+		58ACBD502A1474A2005EF7A4 /* GrayUIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrayUIButton.swift; sourceTree = "<group>"; };
+		58ACBD522A1474AC005EF7A4 /* OrangeUIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrangeUIButton.swift; sourceTree = "<group>"; };
 		58D304E02A11F174005E04CB /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		D3D03F722A10D9B9005AEE77 /* CDS_CarrotJob.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CDS_CarrotJob.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3D03F752A10D9B9005AEE77 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -138,6 +142,7 @@
 		037C35F72A12298600FAC78B /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				58ACBD4F2A14747F005EF7A4 /* Components */,
 				037C35FA2A122A2400FAC78B /* Base */,
 			);
 			path = Common;
@@ -251,6 +256,15 @@
 				037C36202A13792800FAC78B /* Apply.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		58ACBD4F2A14747F005EF7A4 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				58ACBD502A1474A2005EF7A4 /* GrayUIButton.swift */,
+				58ACBD522A1474AC005EF7A4 /* OrangeUIButton.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		58D304E22A11FEF9005E04CB /* Font */ = {
@@ -444,6 +458,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				58ACBD512A1474A2005EF7A4 /* GrayUIButton.swift in Sources */,
 				D3D03F762A10D9B9005AEE77 /* AppDelegate.swift in Sources */,
 				D3D03F782A10D9B9005AEE77 /* SceneDelegate.swift in Sources */,
 				037C360D2A122D5800FAC78B /* ReviewViewController.swift in Sources */,
@@ -452,6 +467,7 @@
 				037C36232A137DC300FAC78B /* HomeNavigationView.swift in Sources */,
 				037C36022A122C6700FAC78B /* HomeViewController.swift in Sources */,
 				037C35E52A121E7C00FAC78B /* UITextField+.swift in Sources */,
+				58ACBD532A1474AC005EF7A4 /* OrangeUIButton.swift in Sources */,
 				037C36162A122EB700FAC78B /* Image.swift in Sources */,
 				037C35ED2A121F3300FAC78B /* String+.swift in Sources */,
 				037C36082A122D2500FAC78B /* JobDetailViewController.swift in Sources */,

--- a/CDS_CarrotJob/CDS_CarrotJob/Presentation/Common/Components/GrayUIButton.swift
+++ b/CDS_CarrotJob/CDS_CarrotJob/Presentation/Common/Components/GrayUIButton.swift
@@ -1,0 +1,20 @@
+//
+//  GrayUIButton.swift
+//  CDS_CarrotJob
+//
+//  Created by KYUBO A. SHIM on 2023/05/17.
+//
+
+import UIKit
+
+class GrayUIButton: UIButton {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/CDS_CarrotJob/CDS_CarrotJob/Presentation/Common/Components/GrayUIButton.swift
+++ b/CDS_CarrotJob/CDS_CarrotJob/Presentation/Common/Components/GrayUIButton.swift
@@ -63,6 +63,7 @@ final class GrayUIButton: UIButton {
 }
 
 extension GrayUIButton {
+    /// type 만 입력하면, 색상과 폰트를 맞춰 그립니다. 크기와 addTarget 만 설정하면 됩니다.
     func setUIOfButtonFor(type: CarrotButtonType) {
         let symbolConfiguration = UIImage.SymbolConfiguration(pointSize: 12, weight: .semibold)
         self.setTitle(type.title, for: .normal)

--- a/CDS_CarrotJob/CDS_CarrotJob/Presentation/Common/Components/GrayUIButton.swift
+++ b/CDS_CarrotJob/CDS_CarrotJob/Presentation/Common/Components/GrayUIButton.swift
@@ -7,14 +7,81 @@
 
 import UIKit
 
-class GrayUIButton: UIButton {
+import SnapKit
+import Then
 
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+final class GrayUIButton: UIButton {
+    
+    enum CarrotButtonType {
+        case lookForOtherJobs
+        case bringMoreReviews
+        case bringMoreLocalJobs
+        case registerCareer
+        
+        var title: String {
+            switch self {
+            case .lookForOtherJobs:
+                return "다른 알바 더보기"
+            case .bringMoreReviews:
+                return "후기 더보기"
+            case .bringMoreLocalJobs:
+                return "우리 동네 알바 더보기"
+            case .registerCareer:
+                return "경력/경험 등록"
+            }
+        }
     }
-    */
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+    }
+    
+    private func setUI() {
+        self.backgroundColor = Color.gray7
+        self.layer.cornerRadius = 6
+        self.setTitleColor(Color.gray1, for: .normal)
+        self.tintColor = Color.gray1
+    }
+    
+    private func setImageInset(isButtonAtLeft isLeft: Bool) {
+        switch isLeft {
+        case true:
+            self.contentEdgeInsets = .init(top: 0, left: 2, bottom: 0, right: 2)
+            self.imageEdgeInsets = .init(top: 0, left: -2, bottom: 0, right: 2)
+            self.titleEdgeInsets = .init(top: 0, left: 2, bottom: 0, right: -2)
+        case false:
+            self.contentEdgeInsets = .init(top: 0, left: 2, bottom: 0, right: 2)
+            self.imageEdgeInsets = .init(top: 0, left: 2, bottom: 0, right: -2)
+            self.titleEdgeInsets = .init(top: 0, left: -2, bottom: 0, right: 2)
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
 
+extension GrayUIButton {
+    func setUIOfButtonFor(type: CarrotButtonType) {
+        let symbolConfiguration = UIImage.SymbolConfiguration(pointSize: 12, weight: .semibold)
+        self.setTitle(type.title, for: .normal)
+        self.titleLabel?.font = .notoSansFont(weightOf: .Bold, sizeOf: .font12)
+
+        switch type {
+        case .lookForOtherJobs:
+            self.setImage(UIImage(systemName: "arrow.clockwise", withConfiguration: symbolConfiguration), for: .normal)
+            self.setImageInset(isButtonAtLeft: true)
+        case .bringMoreReviews:
+            self.setImage(UIImage(systemName: "chevron.right", withConfiguration: symbolConfiguration), for: .normal)
+            self.semanticContentAttribute = .forceRightToLeft
+            self.setImageInset(isButtonAtLeft: false)
+        case .bringMoreLocalJobs:
+            self.setImage(UIImage(systemName: "chevron.right", withConfiguration: symbolConfiguration), for: .normal)
+            self.semanticContentAttribute = .forceRightToLeft
+            self.setImageInset(isButtonAtLeft: false)
+        default:
+            break
+        }
+    }
 }

--- a/CDS_CarrotJob/CDS_CarrotJob/Presentation/Common/Components/OrangeUIButton.swift
+++ b/CDS_CarrotJob/CDS_CarrotJob/Presentation/Common/Components/OrangeUIButton.swift
@@ -50,6 +50,7 @@ class OrangeUIButton: UIButton {
 }
 
 extension OrangeUIButton {
+    /// type 만 입력하면, 색상과 폰트를 맞춰 그립니다. 크기와 addTarget 만 설정하면 됩니다.
     func setUIOfButtonFor(type: CarrotButtonType) {
         self.setTitle(type.title, for: .normal)
         self.titleLabel?.font = .notoSansFont(weightOf: .Bold, sizeOf: .font14)

--- a/CDS_CarrotJob/CDS_CarrotJob/Presentation/Common/Components/OrangeUIButton.swift
+++ b/CDS_CarrotJob/CDS_CarrotJob/Presentation/Common/Components/OrangeUIButton.swift
@@ -1,0 +1,20 @@
+//
+//  OrangeUIButton.swift
+//  CDS_CarrotJob
+//
+//  Created by KYUBO A. SHIM on 2023/05/17.
+//
+
+import UIKit
+
+class OrangeUIButton: UIButton {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/CDS_CarrotJob/CDS_CarrotJob/Presentation/Common/Components/OrangeUIButton.swift
+++ b/CDS_CarrotJob/CDS_CarrotJob/Presentation/Common/Components/OrangeUIButton.swift
@@ -7,14 +7,66 @@
 
 import UIKit
 
+import SnapKit
+import Then
+
 class OrangeUIButton: UIButton {
 
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    enum CarrotButtonType {
+        case inquireOnThePhone
+        case apply
+        case cancel
+        case leave
+        case confirm
+        
+        var title: String {
+            switch self {
+            case .inquireOnThePhone:
+                return "전화문의"
+            case .apply:
+                return "지원하기"
+            case .cancel:
+                return "취소"
+            case .leave:
+                return "나가기"
+            case .confirm:
+                return "확인"
+            }
+        }
     }
-    */
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+    }
+    
+    private func setUI() {
+        self.layer.cornerRadius = 5
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
 
+extension OrangeUIButton {
+    func setUIOfButtonFor(type: CarrotButtonType) {
+        self.setTitle(type.title, for: .normal)
+        self.titleLabel?.font = .notoSansFont(weightOf: .Bold, sizeOf: .font14)
+        
+        switch type {
+        case .inquireOnThePhone:
+            self.setTitleColor(Color.mainColor1, for: .normal)
+            self.backgroundColor = Color.mainColor2
+        case .apply:
+            self.setTitleColor(.white, for: .normal)
+            self.backgroundColor = Color.mainColor1
+        case .cancel:
+            self.setTitleColor(Color.gray4, for: .normal)
+            self.backgroundColor = Color.gray7
+        case .leave, .confirm:
+            self.setTitleColor(.white, for: .normal)
+            self.backgroundColor = Color.mainColor1
+        }
+    }
 }

--- a/CDS_CarrotJob/CDS_CarrotJob/Resource/AssetCatalog/Color.xcassets/mainColor/mainColor1.colorset/Contents.json
+++ b/CDS_CarrotJob/CDS_CarrotJob/Resource/AssetCatalog/Color.xcassets/mainColor/mainColor1.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x4B",
-          "green" : "0x84",
-          "red" : "0xEC"
+          "blue" : "0x3D",
+          "green" : "0x8A",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
## 💭 배경
1. 작업을 시작하기 전에 공용 컴포넌트를 만들어 간단한 디자인 컴포넌트를 제작하기로 했습니다.
실제로 앱의 볼륨은 그렇게 크지 않지만, 확실히 디자이너분들의 디자인을 통해 앱의 UI를
한번에 볼 수 있게되자 디자인 시스템의 필요성을 느꼈습니다.
2. 버튼색을 보니 피그마의 색과 달라 Hex 코드를 보니 달라 수정했습니다. (정이 잘못 아님!)

## 🌳 작업한 내용
- GrayUIButton 구현
- OrangeUIButton 구현
- MainColor1 수정

### 사용법
    buttonGray.do {
        $0.setUIOfButtonFor(type: .bringMoreReviews)
    }

    buttonOrange.do {
        $0.setUIOfButtonFor(type: .inquireOnThePhone)
    }


## 📷 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
<p align="left">
  <img width="200" alt="스크린샷1" src="https://github.com/SOPT-TEAM9-Carrot/Carrot-iOS/assets/89404664/023e28b4-499a-4966-a369-bd65e419c3d8">
  <img width="200" alt="스크린샷1" src="https://github.com/SOPT-TEAM9-Carrot/Carrot-iOS/assets/89404664/85139d77-4884-4a7c-8297-5fa8d6e6d499">
</p>


## 🌈 관련 이슈

- Resolved: #13
